### PR TITLE
Add CFML CFC support

### DIFF
--- a/src/ext/modelist.js
+++ b/src/ext/modelist.js
@@ -62,7 +62,7 @@ var supportedModes = {
     Clojure:     ["clj|cljs"],
     Cobol:       ["CBL|COB"],
     coffee:      ["coffee|cf|cson|^Cakefile"],
-    ColdFusion:  ["cfm"],
+    ColdFusion:  ["cfm|cfc"],
     Crystal:     ["cr"],
     CSharp:      ["cs"],
     Csound_Document: ["csd"],


### PR DESCRIPTION
*Issue #, if available:* https://github.com/ajaxorg/ace/issues/2305


*Description of changes:*
By adding `.cfc` extension to mode list, we support CFML CFC. As CFML CFC is mostly ColdFusion.

In the future, other people could create a mode that extends ColdFusion and adds ColdFusion Component specific mode. But for now people would be helped a lot by having the ColdFusion available for `.cfc` files, as confirmed by @wesleywarren.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
